### PR TITLE
Updated scribus to current version 1.5.5

### DIFF
--- a/Casks/scribus.rb
+++ b/Casks/scribus.rb
@@ -1,10 +1,10 @@
 cask 'scribus' do
-  version '1.4.8'
-  sha256 '9626c35ca5de5da59ac983efac3572318d327b3a921522c9f80a525b039a0af5'
+  version '1.5.5'
+  sha256 'dba7842bf3313c0a2c758a9d8613a7f881774008c10ea1e0445b34b020f6bbbe'
 
   # sourceforge.net/scribus was verified as official when first introduced to the cask
-  url "https://downloads.sourceforge.net/scribus/scribus/#{version}/scribus-#{version}.dmg"
-  appcast 'https://www.scribus.net/downloads/stable-branch/'
+  url "https://sourceforge.net/projects/scribus/files/scribus-devel/#{version}/scribus-#{version}_1013.dmg/download"
+  appcast 'https://wiki.scribus.net/canvas/1.5.5_Release'
   name 'Scribus'
   homepage 'https://www.scribus.net/'
 


### PR DESCRIPTION
The existing version 1.4.8 of scribus is very old and has been updated with 1.5.5 for sometime.  This update uses 1.5.5 dmg which works from OS X 10.13 or higher.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

After making all changes to the cask:

- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` reports no offenses.
- [x] The commit message includes the cask’s name and version.
